### PR TITLE
fix: use stream for fs.createWriteStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ These logs can then be visualized with
 
 ```javascript
 const Trace = require("chrome-trace-event").Tracer;
-const trace = new Trace({
-    noStream: true
-});
+const trace = new Trace();
 trace.pipe(fs.createWriteStream(outPath));
 trace.flush();
 ```


### PR DESCRIPTION
Reference: https://github.com/webpack/webpack/pull/7584

Shouldn't it be a stream that is consumed by fs.createWriteStream?